### PR TITLE
Use `get-parameters-by-path` instead of `describe-parameters`

### DIFF
--- a/doc_source/sysman-paramstore-walk-hierarchies.md
+++ b/doc_source/sysman-paramstore-walk-hierarchies.md
@@ -68,7 +68,7 @@ This walkthrough shows you how to work with parameters and parameter hierarchies
 1. Execute the following command to query for all parameters within a single level\. 
 
    ```
-   aws ssm describe-parameters --filters Key=Name,Values="/MyService/Test"
+   aws ssm get-parameters-by-path --path "/MyService/Test"
    ```
 
 1. Execute the following command to delete two parameters


### PR DESCRIPTION
`get-parameters-by-path` is supposed to be the `get-parameters` alternative for retrieving values by path.

*Description of changes:*

I have simply replaced the command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
