### PR TITLE
Fixing aws:runPowerShellScript Schema v2.2 example and syntax example

### DIFF
--- a/doc_source/ssm-plugins.md
+++ b/doc_source/ssm-plugins.md
@@ -788,7 +788,7 @@ Here is a schemaVersion 2\.2 example:
       "Salutation":{
          "type":"String",
          "description":"(Optional) This is an optional parameter that will be displayed in the output of the command if specified.",
-         "allowedPattern":"[a-zA-Z ]",
+         "allowedPattern":"[a-zA-Z]",
          "default":"World"
       }
    },
@@ -799,14 +799,14 @@ Here is a schemaVersion 2\.2 example:
          "inputs":{
             "timeoutSeconds":60,
             "runCommand":[
-               "$salutation = '{{Salutation}}'",
+               "$salutation = '{{ Salutation }}'",
                "",
                "if ( [String]::IsNullOrWhitespace( $salutation ) )",
                "{",
                "  $salutation = 'anonymous'",
                "}",
                "",
-               "Write-Host 'Hello $salutation'"
+               "Write-Host ('Hello {0}' -f $salutation)"
             ]
          }
       }

--- a/doc_source/ssm-plugins.md
+++ b/doc_source/ssm-plugins.md
@@ -788,7 +788,7 @@ Here is a schemaVersion 2\.2 example:
       "Salutation":{
          "type":"String",
          "description":"(Optional) This is an optional parameter that will be displayed in the output of the command if specified.",
-         "allowedPattern":"[a-zA-Z]",
+         "allowedPattern":"[a-zA-Z ]+",
          "default":"World"
       }
    },

--- a/doc_source/ssm-plugins.md
+++ b/doc_source/ssm-plugins.md
@@ -771,8 +771,8 @@ Run PowerShell scripts or specify the path to a script to run\. This plugin runs
     "action":"aws:runPowerShellScript",
     "name":"step name",
     "inputs":{
-      "timeoutSeconds":"Timeout in seconds",
-      "runCommand":"[Command to execute]"
+      "timeoutSeconds":Timeout in seconds,
+      "runCommand":[Command to execute]
     }
   }
 ]

--- a/doc_source/ssm-plugins.md
+++ b/doc_source/ssm-plugins.md
@@ -766,16 +766,16 @@ Run PowerShell scripts or specify the path to a script to run\. This plugin runs
 **Syntax for 2\.2 SSM document**
 
 ```
-"mainSteps": [
-   {
-      "action":"aws:runPowerShellScript",
-      "name:":"step name",
-      "inputs":{
-         "timeoutSeconds":Timeout in seconds,
-         "runCommand:":[Command to execute]
-                }
+"mainSteps":[
+  {
+    "action":"aws:runPowerShellScript",
+    "name":"step name",
+    "inputs":{
+      "timeoutSeconds":"Timeout in seconds",
+      "runCommand":"[Command to execute]"
     }
-   ]
+  }
+]
 ```
 
 Here is a schemaVersion 2\.2 example:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Fixing aws:runPowerShellScript Schema v2.2 example.
Regex pattern has whitespace at the end.
Write-Host line is using single quotes so variable will not be parsed, converted to format string.
Removing `:` characters from key names

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
