### PR TITLE
Improve python in Parameter Store Lambda example

### DIFF
--- a/doc_source/sysman-paramstore-about.md
+++ b/doc_source/sysman-paramstore-about.md
@@ -145,18 +145,19 @@ from __future__ import print_function
  
 import json
 import boto3
+
 ssm = boto3.client('ssm', 'us-east-2')
- def get_parameters():
+
+def get_parameter():
     response = ssm.get_parameters(
-        Names=['LambdaSecureString'],WithDecryption=True
+        Names=['LambdaSecureString'],
+        WithDecryption=True,
     )
-    for parameter in response['Parameters']:
-        return parameter['Value']
+    return response['Parameters'][0]['Value']
         
 def lambda_handler(event, context):
-    value = get_parameters()
-    print("value1 = " + value)
-    return value  # Echo back the first key value
+    value = get_parameter()
+    print("value1 = " + value) . # print into logs
 ```
 
 **Related topics**  


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

* Add a bit of vertical whitespace for readability
* Fix indentation of first function
* Rename `get_parameters` -> `get_parameter` to indicate it returns only one value
* Use simpler, more obvious `return` statement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
