### PR TITLE
Remove the s in http://hostname:port

### DIFF
--- a/doc_source/sysman-proxy-with-ssm-agent.md
+++ b/doc_source/sysman-proxy-with-ssm-agent.md
@@ -18,7 +18,7 @@ Instances created from an Amazon Linux AMI that are using a proxy must be runnin
 
    ```
    env http_proxy=http://hostname:port
-   env https_proxy=https://hostname:port
+   env https_proxy=http://hostname:port
    env no_proxy=169.254.169.254
    ```
 **Note**  
@@ -59,7 +59,7 @@ The steps in the following procedure describe how to configure SSM Agent to use 
    ```
    [Service]
    Environment="http_proxy=http://hostname:port"
-   Environment="https_proxy=https://hostname:port"
+   Environment="https_proxy=http://hostname:port"
    Environment="no_proxy=169.254.169.254"
    ```
 **Note**  


### PR DESCRIPTION
Using and https proxy url for https traffic is a bit misleading for people not proxy aware as it means that the proxy listener is actually using a certificate which is often not the case.
I would recommend to use the same http://hostname:port as it is often the same proxy settings for both http and https traffic.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
