### PR TITLE
Update troubleshooting-remote-commands.md

### DIFF
--- a/doc_source/troubleshooting-remote-commands.md
+++ b/doc_source/troubleshooting-remote-commands.md
@@ -78,7 +78,7 @@ SSM Agent logs information in the following files\. The information in these fil
 
 **On Windows**
 + %PROGRAMDATA%\\Amazon\\SSM\\Logs\\amazon\-ssm\-agent\.log
-+ %PROGRAMDATA%\\Amazon\\SSM\\Logs\\error\.log
++ %PROGRAMDATA%\\Amazon\\SSM\\Logs\\errors\.log
 
 **Note**  
 The default filename of the seelog is seelog\.xml\.template\. If you modify a seelog, you must rename the file to seelog\.xml\.


### PR DESCRIPTION
The error log file name in Windows is %PROGRAMDATA%\Amazon\SSM\Logs\errors.log. In the documentation, it is incorrectly mentioned as %PROGRAMDATA%\Amazon\SSM\Logs\error.log.

*Issue #, if available:*

*Description of changes:*
Changed the file name from error.log to errors.log. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
