### PR TITLE
Update description key-id values accepted by awscli

### DIFF
--- a/doc_source/param-create-cli.md
+++ b/doc_source/param-create-cli.md
@@ -78,7 +78,7 @@ Before you create a `SecureString` parameter, read about the requirements for th
 1. Execute the following command to create a parameter\.
 
    ```
-   aws ssm put-parameter --name "parameter_name" --value "parameter value" --type SecureString  --key-id "a KMS CMK ID, a KMS CMK ARN, an alias name, or an alias ARN"
+   aws ssm put-parameter --name "parameter_name" --value "parameter value" --type SecureString  --key-id "a KMS CMK ID or ARN"
    ```
 **Note**  
 To use the default AWS KMS CMK assigned to your account, remove the `key-id` parameter from the command\.


### PR DESCRIPTION
The previous text `--key-id "a KMS CMK ID, a KMS CMK ARN, an alias name, or an alias ARN"` incorrectly applied that the tool supported aliases but in fact it returns errors if you attempt to use anything but the key ID or ARN.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
