### PR TITLE
Fixing PropertySelector reference.

### DIFF
--- a/doc_source/automation-aws-apis-calling.md
+++ b/doc_source/automation-aws-apis-calling.md
@@ -81,7 +81,7 @@ mainSteps:
     Api: DescribeInstanceStatus
     InstanceIds:
     - "{{ getInstanceId.Value }}"
-    PropertySelector: "$.Instances.InstanceState.Name"
+    PropertySelector: "$.InstanceStatuses..InstanceState.Name"
     DesiredValues:
     - running
 - name: assertStep
@@ -91,7 +91,7 @@ mainSteps:
     Api: DescribeInstanceStatus
     InstanceIds:
     - "{{ getInstanceId.Value }}"
-    PropertySelector: "$.Instances.InstanceState.Name"
+    PropertySelector: "$.InstanceStatuses..InstanceState.Name"
     DesiredValues:
     - running
 outputs:


### PR DESCRIPTION
When working through the example I noticed that the with `"$.Instances.InstanceState.Name"` the step would continuously spin. I would not be able to get pass the steps and would have to cancel the automation execution. I started to look at the API calls and noticed that the response from the `DescribeInstanceStatus` did not match what was in the example. This lines up with the response found on these pages: [boto3 describe_instance_status docs][1] and [ec2 cli][2].

[1]: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_instance_status
[2]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instance-status.html#output

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
