### PR TITLE
Removed typo from IAM policy example

### DIFF
--- a/doc_source/auth-and-access-control-iam-identity-based-access-control.md
+++ b/doc_source/auth-and-access-control-iam-identity-based-access-control.md
@@ -26,7 +26,7 @@ The following is an example of a permissions policy that allows a user to delete
       ]
     }
   ]
-}co
+}
 ```
 
 ## Permissions Required to Use the AWS Systems Manager Console<a name="console-permissions"></a>


### PR DESCRIPTION
Removed typo `co` from the end of an IAM policy example

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._