### PR TITLE
Incorrect flag for terminate-session

### DIFF
--- a/doc_source/session-manager-working-with-sessions-end.md
+++ b/doc_source/session-manager-working-with-sessions-end.md
@@ -26,9 +26,9 @@ To terminate a session using the CLI, run the following command:
 To use the AWS CLI to run session commands, the Session Manager plugin must also be installed on your local machine\. For information, see [\(Optional\) Install the Session Manager Plugin for the AWS CLI](session-manager-working-with-install-plugin.md)\.
 
 ```
-aws ssm terminate-session --target instance-id
+aws ssm terminate-session --session-id Session-ID
 ```
 
-*instance\-id* represents of the ID of an instance you currently have an active Session Manager session with\.
+*Session\-ID* represents of the ID of a session you currently have an active Session Manager session with\.
 
 For more information about the terminate\-session command, see [terminate\-session](https://docs.aws.amazon.com/cli/latest/reference/ssm/terminate-session.html) in the AWS Systems Manager section of the AWS CLI Command Reference\.


### PR DESCRIPTION
ssm terminate-session should have --session-id flag set rather then --instance-id to make it work.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
