### PR TITLE
Update Create the Required IAM Role.md

### DIFF
--- a/doc_source/systems-manager-inventory-query.md
+++ b/doc_source/systems-manager-inventory-query.md
@@ -88,9 +88,9 @@ You must create a new IAM role called **Amazon\-GlueServiceRoleForSSM** that ena
 
 1. In the navigation pane, choose **Roles**, and then choose **Create role**\.
 
-1. On the **Select type of trusted entity** page, under **AWS Service**, choose **EC2**\. And then choose **Next: Permissions**\.
+1. On the **Select type of trusted entity** page, under **AWS Service**, choose **Glue**\. And then choose **Next: Permissions**\.
 **Note**  
-If the **Select your use case** section appears, choose **EC2 Role for Simple Systems Manager**\.
+If the **Select your use case** section appears, choose **Glue**\.
 
 1. On the **Attach permissions policies** page, use the Search field to search for **AWSGlueServiceRole**\. Choose the option beside this policy, and then choose **Next: Review**\. 
 


### PR DESCRIPTION
The steps given in Task 2 section  will create a service role for EC2 with EC2 trust policy, AWS Glue can't access the Resource Data Sync using this role and users will see assume role error on console. The user must select Glue instead of EC2 in order to create the role with the correct trust policy when using IAM console.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
