### PR TITLE
Fix example IAM Policy for automation-ec2reset.md

### DIFF
--- a/doc_source/automation-ec2reset.md
+++ b/doc_source/automation-ec2reset.md
@@ -112,6 +112,7 @@ If you create a new IAM managed policy, you must also attach the **AmazonSSMAuto
             "ec2:DeleteInternetGateway",
             "ec2:CreateSubnet",
             "ec2:DeleteSubnet",
+            "ec2:ModifySubnetAttribute",
             "ec2:CreateRoute",
             "ec2:DeleteRoute",
             "ec2:CreateRouteTable",
@@ -121,6 +122,9 @@ If you create a new IAM managed policy, you must also attach the **AmazonSSMAuto
             "ec2:CreateVpcEndpoint",
             "ec2:DeleteVpcEndpoints",
             "ec2:ModifyVpcEndpoint",
+            "ec2:DetachVolume",
+            "ec2:AttachVolume",
+            "ec2:ModifyInstanceAttribute", 
             "ec2:Describe*"
          ],
          "Resource": "*",


### PR DESCRIPTION
The example IAM Policy was missing four permissions which were required when providing a Role ARN to Systems Manager, as the Automation document will fail to execute correctly and leave orphaned resources behind in the AWS account without recovering access to the user's EC2 instance.

*Issue #, if available:*

*Description of changes:*
Added additional required IAM permissions to the sample policy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
