### PR TITLE
Correcting example commands to modify ssm-user sudo permissions

### DIFF
--- a/doc_source/session-manager-getting-started-ssm-user-permissions.md
+++ b/doc_source/session-manager-getting-started-ssm-user-permissions.md
@@ -19,7 +19,7 @@ Use one of the following procedures to disable or enable the ssm\-user account s
 
     ```
     cd /etc/sudoers.d
-    echo "User rules for ssm-user" > ssm-agent-users
+    echo "# User rules for ssm-user" > ssm-agent-users
     ```
 
     \-or\-
@@ -28,7 +28,7 @@ Use one of the following procedures to disable or enable the ssm\-user account s
 
     ```
     cd /etc/sudoers.d 
-    echo "ssm-user ALL=(ALL) NOPASSWD:ALL" >> ssm-agent-users
+    echo "ssm-user ALL=(ALL) NOPASSWD:ALL" > ssm-agent-users
     ```
 
 **Use the command line to modify ssm\-user sudo permissions**


### PR DESCRIPTION
*Description of changes:* The current commands for modifying ssm-user sudo permissions are not correct. The example for removing permissions is missing a "#" character, and the command parameters for restoring access should overwrite rather than append to the sudoers.d configuration


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
