### PR TITLE
Update automation-aws-setupipmonitoringfromvpc.md

### DIFF
--- a/doc_source/automation-aws-setupipmonitoringfromvpc.md
+++ b/doc_source/automation-aws-setupipmonitoringfromvpc.md
@@ -114,6 +114,16 @@ It is recommended that the user who executes the automation have the **AmazonSSM
       },
       {
          "Action": [
+            "ec2:DescribeSubnets",
+            "ec2:createSecurityGroup",
+            "ec2:deleteSecurityGroup",
+            "ec2:AuthorizeSecurityGroupEgress"
+          ],
+          "Resource": "*",
+          "Effect": "Allow"
+      },
+      {
+         "Action": [
             "cloudwatch:DeleteDashboards"
          ],
          "Resource": [


### PR DESCRIPTION
Added additional permissions that are required for step 1, 4 and 5.

*Issue #, if available:*

N/A

*Description of changes:*

The documented policy result in a failure on step 1. After some testing I figured out the rest of the permissions that required for deployment and cleanup.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
