### PR TITLE
Added missing ssm API permissions to the following

### DIFF
--- a/doc_source/systems-manager-setting-up-messageAPIs.md
+++ b/doc_source/systems-manager-setting-up-messageAPIs.md
@@ -11,10 +11,10 @@ If you monitor API calls, you might see calls to the following APIs\.
 + ssmmessages:CreateDataChannel
 + ssmmessages:OpenControlChannel
 + ssmmessages:OpenDataChannel
-+ UpdateInstanceInformation
-+ ListInstanceAssociations
-+ DescribeInstanceProperties
-+ DescribeDocumentParameters
++ ssm:UpdateInstanceInformation
++ ssm:ListInstanceAssociations
++ ssm:DescribeInstanceProperties
++ ssm:DescribeDocumentParameters
 
 These special calls are used by Systems Manager for various operations\.
 


### PR DESCRIPTION
ssm:UpdateInstanceInformation
ssm:ListInstanceAssociations
ssm:DescribeInstanceProperties
ssm:DescribeDocumentParameters

It is not obvious which IAM permissions the last 4 relate to and had to refer to https://iam.cloudonaut.io/reference/ssm.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
