### PR TITLE
Remove mention of linux package manager in OSX instructions

### DIFF
--- a/doc_source/session-manager-working-with-install-plugin.md
+++ b/doc_source/session-manager-working-with-install-plugin.md
@@ -72,8 +72,6 @@ The bundled installer does not support installing to paths that contain spaces\.
    ```
    unzip sessionmanager-bundle.zip
    ```
-**Note**  
-If you don't have `unzip`, use your Linux distribution's built in package manager to install it\. 
 
 1. Run the install command:
 


### PR DESCRIPTION

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
