### PR TITLE
Correct the Windows tool used to restart a service

### DIFF
--- a/doc_source/troubleshooting-remote-commands.md
+++ b/doc_source/troubleshooting-remote-commands.md
@@ -126,7 +126,7 @@ Use the follow procedure to enable SSM Agent debug logging on Windows Server and
    ```
 
 1. Restart SSM Agent\.
-   + **Windows Server**: Use Windows Task Manager to restart AmazonSSMAgent\.exe\.
+   + **Windows Server**: Use Windows Services Manager to restart the Amazon SSM Agent.
    + **Linux**: Run the following command:
 
      ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Documentation incorrectly says to use the _Windows Task Manager_ to restart the SSM agent. The _Services_ mgr is the more appropriate tool.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
