### PR TITLE
Correct install instructions for ubuntu 18.04

### DIFF
--- a/doc_source/sysman-install-managed-linux.md
+++ b/doc_source/sysman-install-managed-linux.md
@@ -76,7 +76,7 @@ https://s3.us-west-1.amazonaws.com/amazon-ssm-us-west-1/latest/linux_amd64/amazo
    sudo systemctl start amazon-ssm-agent
    ```
 
-   **On Ubuntu**
+   **On Ubuntu <= 16.04**
 
    ```
    mkdir /tmp/ssm
@@ -85,6 +85,15 @@ https://s3.us-west-1.amazonaws.com/amazon-ssm-us-west-1/latest/linux_amd64/amazo
    sudo service amazon-ssm-agent stop
    sudo amazon-ssm-agent -register -code "activation-code" -id "activation-id" -region "region" 
    sudo service amazon-ssm-agent start
+   ```
+   
+   **On Ubuntu >= 18.04**
+
+   ```
+   sudo snap install amazon-ssm-agent --classic
+   sudo systemctl stop snap.amazon-ssm-agent.amazon-ssm-agent.service
+   sudo /snap/amazon-ssm-agent/current/amazon-ssm-agent -register -code "activation-code" -id "activation-id" -region "region" 
+   sudo systemctl start snap.amazon-ssm-agent.amazon-ssm-agent.service
    ```
 
    **On Raspbian**


### PR DESCRIPTION
We don't allow deb installs for 18.04 and above. See "On Ubuntu Server 18.04, use Snaps only." on https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-manual-agent-install.html#agent-install-ubuntu-snap. Updating the docs to include the correct instructions.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
