### PR TITLE
Update ssm-plugins.sd for timeoutSeconds type

### DIFF
--- a/doc_source/ssm-plugins.md
+++ b/doc_source/ssm-plugins.md
@@ -788,7 +788,7 @@ Here is a schemaVersion 2\.2 example:
          "action":"aws:runPowerShellScript",
          "name":"DisplaySalutation",
          "inputs":{
-            "timeoutSeconds":60,
+            "timeoutSeconds":"60",
             "runCommand":[
                "$salutation = '{{ Salutation }}'",
                "",


### PR DESCRIPTION
*Description of changes:*
Adjusts the variable type for "timeoutSeconds" in schema 2.2 example from integer to string. Elsewhere in the docs "timeoutSeconds" is referenced as a string but this one example has it shown as an integer, which is not acceptable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
