### PR TITLE
Explain constraint for denied `GetParametersByPath` action

### DIFF
--- a/doc_source/sysman-paramstore-su-organize.md
+++ b/doc_source/sysman-paramstore-su-organize.md
@@ -63,7 +63,7 @@ aws ssm get-parameters-by-path --path /Prod/ERP/SAP --with-decryption
 ```
 
 **Restricting IAM Permissions Using Hierarchies**  
-Using hierarchies and AWS Identity and Access Management \(IAM\) policies for Parameter Store API actions, you can provide or restrict access to all parameters in one level of a hierarchy\. The following example policy allows all Parameter Store operations on all parameters for the AWS account 123456789012 in the US East \(Ohio\) Region \(us\-east\-2\)\. The user can't create parameters because the `PutParameter` action is explicitly denied\. This policy also forbids the user from calling the `GetParametersByPath` action\. 
+Using hierarchies and AWS Identity and Access Management \(IAM\) policies for Parameter Store API actions, you can provide or restrict access to all parameters in one level of a hierarchy\. The following example policy allows all Parameter Store operations on all parameters for the AWS account 123456789012 in the US East \(Ohio\) Region \(us\-east\-2\)\. The user can't create parameters because the `PutParameter` action is explicitly denied\. This policy also forbids the user from calling the `GetParametersByPath` action for parameters within the `/Dev/ERP/Oracle/*` hierarchy\. 
 
 ```
 {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When reading the text first I understood that access to `GetParametersByPath` for all parameters would be denied which made no sense to me. I understood it was correct when I read the snippet. The text now correlates with the snippet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
