### PR TITLE
Bring IAM quickstart's example tags in line with description.

### DIFF
--- a/doc_source/getting-started-restrict-access-quickstart.md
+++ b/doc_source/getting-started-restrict-access-quickstart.md
@@ -220,7 +220,7 @@ These policies provide administrators the ability to start a session to instance
 You can create a policy that allows administrators to perform these tasks from only the Session Manager console and AWS CLI, from only the Amazon EC2 console, or from all three\.
 
 **Note**  
-Replace *tag\-key* and *tag\-value* with the tags applied to your instances\. Replace *region* and *account\-id* with your AWS Region and AWS Account ID, such as `us-east-2` and `111122223333`\.
+Replace *region* and *account\-id* with your AWS Region and AWS Account ID, such as `us-east-2` and `111122223333`\.
 
 Choose from the following tabs to view the sample policy for the access scenario you want to support\.
 
@@ -243,8 +243,8 @@ Use this sample policy to provider administrators with the ability to perform se
             ],
             "Condition": {
                 "StringLike": {
-                    "ssm:resourceTag/tag-key": [
-                        "tag-value"
+                    "ssm:resourceTag/Finance": [
+                        "WebServers"
                     ]
                 }
             }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
There is a discrepancy between the tags documented (`Key=Finance,Value=WebServers`) and the keys in the example policy (`Key=tag-key,Value=tag-value`). This change makes the policy consistent with the paragraph before it.

The divergence happened in 7ded1692 and appears to be at least partially intentional. I reverted back to the former state for consistency, as there are many other references to this same set of tags elsewhere in the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
