### PR TITLE
Add note regarding systemd percent character escape requirements

### DIFF
--- a/doc_source/sysman-proxy-with-ssm-agent.md
+++ b/doc_source/sysman-proxy-with-ssm-agent.md
@@ -86,6 +86,9 @@ The steps in the following procedure describe how to configure SSM Agent to use 
 **Note**  
 You must add the `no_proxy` setting to the file and specify the IP address listed here\. It is the instance metadata endpoint for Systems Manager\. Without this IP address, calls to Systems Manager fail\.
 
+**Note**
+If you need to use a `%` character in these strings (for example in a proxy password), you need to escape it as `%%` or systemd will ignore the whole line\.
+
 1. Save your changes\. The system creates a file named `amazon-ssm-agent.override` \(or `override.conf` on Amazon Linux 2\) instances in the `etc/systemd/system/amazon-ssm-agent.service.d` folder\.
 
 1. Restart SSM Agent by using the following commands:


### PR DESCRIPTION
Description of changes:
Add note regarding systemd percent character escape requirements when editing its Environment lines for the amazon-ssm-agent service.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
