### PR TITLE
Update automation-walk-patch-windows-ami-simplify.md

### DIFF
--- a/doc_source/automation-walk-patch-windows-ami-simplify.md
+++ b/doc_source/automation-walk-patch-windows-ami-simplify.md
@@ -214,7 +214,7 @@ You must change the values of *assumeRole* and *IamInstanceProfileName* in this 
                   "{{ startInstances.InstanceIds }}"
                ],
                "Parameters":{
-                  "UpdateLevel":"Important"
+                  "SeverityLevels":"Important"
                }
             }
          },


### PR DESCRIPTION
I have tested this in my lab and it seems like AWS has changed the document name called: AWS-InstallWindowsUpdates Line number 41 from UpdateLevel to SeverityLevels.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
