### PR TITLE
Removed extra 'more' from Systems Manager Document

### DIFF
--- a/doc_source/features.md
+++ b/doc_source/features.md
@@ -132,6 +132,6 @@ Systems Manager uses the following shared resources for managing and configuring
 ------
 #### [ Systems Manager Documents ]
 
-A [Systems Manager document](sysman-ssm-docs.md) \(SSM document\) defines the actions that Systems Manager performs\. SSM document types include *Command* documents, which are used by State Manager and Run Command, and *Automation* documents, which are used by Systems Manager Automation\. Systems Manager includes more dozens of pre\-configured documents that you can use by specifying parameters at runtime\. Documents can be expressed in JSON or YAML, and include steps and parameters that you specify\.
+A [Systems Manager document](sysman-ssm-docs.md) \(SSM document\) defines the actions that Systems Manager performs\. SSM document types include *Command* documents, which are used by State Manager and Run Command, and *Automation* documents, which are used by Systems Manager Automation\. Systems Manager includes dozens of pre\-configured documents that you can use by specifying parameters at runtime\. Documents can be expressed in JSON or YAML, and include steps and parameters that you specify\.
 
 ------


### PR DESCRIPTION
*Description of changes:*

The Systems Manager Documents section included the line 

> Systems Manager includes more dozens of pre-configured documents that you can use by specifying parameters at runtime.

Removing the "more" from this sentence is the smallest change to make the sentence read well.

> Systems Manager includes ~~more~~ dozens of pre-configured documents that you can use by specifying parameters at runtime.

Alternatively the word "dozens" can be made singular and additional grammar can be added so the the line reads: 

> Systems Manager includes more than a dozen pre-configured documents that you can use by specifying parameters at runtime.

But is a significantly larger change for a nearly identical grammatical effect.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
