### PR TITLE
Moving the note from assertAwsResourceProperty

### DIFF
--- a/doc_source/automation-action-waitForAwsResourceProperty.md
+++ b/doc_source/automation-action-waitForAwsResourceProperty.md
@@ -2,6 +2,9 @@
 
 The aws:waitForAwsResourceProperty action enables your Automation workflow to wait for a specific resource state or event state before continuing the workflow\. For more information and examples of how to use this action, see [Invoking other AWS services from a Systems Manager Automation workflow](automation-aws-apis-calling.md)\.
 
+**Note**  
+The default timeout value for this action is 3600 seconds \(one hour\)\. You can limit or extend the timeout by specifying the `timeoutSeconds` parameter for an `aws:waitForAwsResourceProperty` step\.
+
 **Input**  
 Inputs are defined by the API action that you choose\.
 


### PR DESCRIPTION
The note seems to be about waitForAwsResourceProperty but was on assertAwsResourceProperty page.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
