### PR TITLE
Removing the Note.

### DIFF
--- a/doc_source/automation-action-assertAwsResourceProperty.md
+++ b/doc_source/automation-action-assertAwsResourceProperty.md
@@ -4,9 +4,6 @@ The aws:assertAwsResourceProperty action enables you to assert a specific resour
 
 For more information and examples of how to use this action, see [Invoking other AWS services from a Systems Manager Automation workflow](automation-aws-apis-calling.md)\.
 
-**Note**  
-The default timeout value for this action is 3600 seconds \(one hour\)\. You can limit or extend the timeout by specifying the `timeoutSeconds` parameter for an `aws:waitForAwsResourceProperty` step\.
-
 **Input**  
 Inputs are defined by the API action that you choose\. 
 


### PR DESCRIPTION
The note seems to be related to aws:waitForAwsResourceProperty not to this action. Moved the note to the correct page. 

https://github.com/awsdocs/aws-systems-manager-user-guide/compare/master...aaalzand:patch-4
https://github.com/awsdocs/aws-systems-manager-user-guide/pull/106

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
