### PR TITLE
Remove misleading line.

### DIFF
--- a/doc_source/automation-actions.md
+++ b/doc_source/automation-actions.md
@@ -104,7 +104,6 @@ Required: No
 
 timeoutSeconds  
 The execution timeout value for the step\. If the timeout is reached and the value of `maxAttempts` is greater than 1, then the step is not considered to have timed out until all retries have been attempted\.   
-The `aws:changeInstanceState` action has a default `timeoutSeconds` value of 3600\. For all other actions, there is no default value\.  
 Type: Integer  
 Required: No
 


### PR DESCRIPTION
Some actions like waitForAwsResourceProperty does have default value as well. The same line is already mentioned under the changeInstanceState page
https://docs.aws.amazon.com/systems-manager/latest/userguide/automation-action-changestate.html. 

This also related to the followings pull requests
https://github.com/awsdocs/aws-systems-manager-user-guide/pull/106
https://github.com/awsdocs/aws-systems-manager-user-guide/pull/107

Thanks!

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
