### PR TITLE
Update sysman-paramstore-versions.md

### DIFF
--- a/doc_source/sysman-paramstore-versions.md
+++ b/doc_source/sysman-paramstore-versions.md
@@ -54,7 +54,7 @@ aws ec2 run-instances \
 ```
 
 **Note**  
-Currently, using `resolve` and a parameter value works only with the `--instance-id` option and a parameter that contains an Amazon Machine Image \(AMI\) as its value\. For more information, see [Native parameter support for Amazon Machine Image IDs](parameter-store-ec2-aliases.md)\.
+Currently, using `resolve` and a parameter value works only with the `--image-id` option and a parameter that contains an Amazon Machine Image \(AMI\) as its value\. For more information, see [Native parameter support for Amazon Machine Image IDs](parameter-store-ec2-aliases.md)\.
 
 Here is an example for specifying version 2 of a parameter named `MyRunCommandParameter` in an SSM document\.
 


### PR DESCRIPTION
Fixing a typo: `--instance-id` is wrong, it should be `--image-id`.

*Issue #, if available:*

*Description of changes:*
`--instance-id` is not a parameter for `aws ec2 run-instances`; this must be a typo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
