### PR TITLE
Update automation-action-executeScript.md to add note for timeout

### DIFF
--- a/doc_source/automation-action-executeScript.md
+++ b/doc_source/automation-action-executeScript.md
@@ -2,6 +2,9 @@
 
 Runs the Python or PowerShell script provided, using the specified runtime and handler\. \(For PowerShell, the handler is not required\.\)
 
+**Note**  
+Each `executeScript` action can run up to a maximum duration of 10 minutes\. The step will timeout after this period\.
+
 Currently, the `aws:executeScript` action contains the following preinstalled PowerShell Core modules\. 
 + Microsoft\.PowerShell\.Host
 + Microsoft\.PowerShell\.Management


### PR DESCRIPTION
The maximum run time limit for executeScript action is specified in Systems Manager service quotas documentation at https://docs.aws.amazon.com/general/latest/gr/ssm.html#limits_ssm. Adding that information to action details page so that nobody miss that information.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
