### PR TITLE
Update timeoutSeconds section in automation-actions.md

### DIFF
--- a/doc_source/automation-actions.md
+++ b/doc_source/automation-actions.md
@@ -54,7 +54,7 @@ Required: No
 
 [timeoutSeconds](#timeProp)  
 The execution timeout value for the step\. If the timeout is reached and the value of `maxAttempts` is greater than 1, then the step is not considered to have timed out until all retries have been attempted\.   
-The `aws:changeInstanceState` action has a default `timeoutSeconds` value of 3600\. For all other actions, there is no default value\.  
+The `aws:changeInstanceState` and `aws:assertAwsResourceProperty` actions have a default `timeoutSeconds` value of 3600\. The default and maximum timeout for `aws:executeScript` action is 600. For all other actions, there is no default value\.  
 Type: Integer  
 Required: No
 


### PR DESCRIPTION
aws:assertAwsResourceProperty action also has a default 3600s timeout ( https://docs.aws.amazon.com/systems-manager/latest/userguide/automation-action-assertAwsResourceProperty.html) . Similarly, aws:executeScript has a maximum timeout of 600s. Adding this information to the timeoutSeconds details.

*Issue #, if available:*

*Description of changes:*
Update timeoutSeconds section to add the default value of aws:asetAwsResourceProperty and aws:executeScript actions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
