### PR TITLE
Update getting-started-create-preferences-cli.md

### DIFF
--- a/doc_source/getting-started-create-preferences-cli.md
+++ b/doc_source/getting-started-create-preferences-cli.md
@@ -20,7 +20,7 @@ For information about using command line tools to update existing Session Manage
            "cloudWatchLogGroupName": "",
            "cloudWatchEncryptionEnabled": true,
            "kmsKeyId": "",
-           "runAsEnabled": "",
+           "runAsEnabled": false,
            "runAsDefaultUser": ""
        }
    }


### PR DESCRIPTION
If runAsEnabled is set to "",  sessions will appear to connect, but commands can not be run.  In the AWS console you only see a blinking cursor and from the command line you only see what you type.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
