### PR TITLE
Grammatical Correction: Removed extra 'the' in the step 2 in the Sess…

### DIFF
--- a/doc_source/session-manager-working-with-install-plugin.md
+++ b/doc_source/session-manager-working-with-install-plugin.md
@@ -34,7 +34,7 @@ For best results, we recommend starting sessions on Windows clients using the Wi
    https://s3.amazonaws.com/session-manager-downloads/plugin/latest/windows/SessionManagerPluginSetup.exe
    ```
 
-1. Run the downloaded installer and follow the on\-screen the instructions\.
+1. Run the downloaded installer and follow the on\-screen instructions\.
 
    Leave the install location box blank to install the plugin to the default directory:
    + `C:\%PROGRAMFILES%\Amazon\SessionManagerPlugin\bin\` 


### PR DESCRIPTION
Session Manager installation instructions for Windows section

Removed extra 'the' in the step 2 in the Session Manager installation instructions for Windows section
Change: "follow the on-screen the instructions" to "follow the on-screen instructions"

*Issue #, if available:*

*Description of changes:*

Removed extra 'the' in the step 2 in the Session Manager installation instructions for Windows section
Change: "follow the on-screen the instructions" to "follow the on-screen instructions"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
