### PR TITLE
Updated information under DocumentName

### DIFF
--- a/doc_source/automation-action-executeAutomation.md
+++ b/doc_source/automation-action-executeAutomation.md
@@ -49,7 +49,7 @@ inputs:
 ------
 
 DocumentName  
-The name of the secondary Automation document to run during the step\. The document must belong to the same AWS account as the primary Automation document\.  
+The name of the secondary Automation document to run during the step\. The document must belong to the same AWS account as the primary Automation document. If you're using a document shared with you by a different AWS account, specify the Amazon Resource Name (ARN) of the document. For more information about using shared documents, see [Using shared SSM documents](ssm-using-shared.md)\.\
 Type: String  
 Required: Yes
 


### PR DESCRIPTION
Added details under DocumentName section to reflect information that is required when executing SSM documents that have been shared by another AWS Accounts. As only specifying name of Shared SSM document instead of complete ARN will result in Automation failure.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
