### PR TITLE
Clarify the need to open port 443 outbound if you don't use a VPC endpoint

### DIFF
--- a/doc_source/systems-manager-prereqs.md
+++ b/doc_source/systems-manager-prereqs.md
@@ -20,7 +20,7 @@ This topic provides an overview of these prerequisites\.
 
 1. \(Recommended\) Create a VPC endpoint in Amazon Virtual Private Cloud to use with Systems Manager\. 
 
-   If you don't use a VPC, you must configure your managed instances to allow `HTTPS` \(port 443\) outbound traffic to the Systems Manager endpoints\. For information, see [\(Optional\) Create a Virtual Private Cloud endpoint\.](setup-create-vpc.md)
+   If you don't use a VPC endpoint, you must configure your managed instances to allow `HTTPS` \(port 443\) outbound traffic to the Systems Manager endpoints\. For information, see [\(Optional\) Create a Virtual Private Cloud endpoint\.](setup-create-vpc.md)
 
 1. On on\-premises servers, VMs, and EC2 instances created from AMIs that are not supplied by AWS, ensure that a Transport Layer Security \(TLS\) certificate is installed\.
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This clarifies the need for a port 443 outbound to be on open if you don't use a VPC endpoint, rather than a VPC.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
