### PR TITLE
Update sysman-manual-agent-install-macos2.md

### DIFF
--- a/doc_source/sysman-manual-agent-install-macos2.md
+++ b/doc_source/sysman-manual-agent-install-macos2.md
@@ -26,7 +26,7 @@ Connect to your macOS instance and perform the following steps to install SSM Ag
 
 1. Check the status of the agent\.
 
-   To determine if SSM Agent is running, check the agent log at `var/log/amazon/ssm/amazon-ssm-agent.log` 
+   To determine if SSM Agent is running, check the agent log at `/var/log/amazon/ssm/amazon-ssm-agent.log` 
 
 1. Run the following commands if the previous command returns the message "amazon\-ssm\-agent is stopped\."
 


### PR DESCRIPTION
Fixing /var/log/... directory path

*Issue #, if available:*
Logs path wasn't correct - missing the initial forward slash.

*Description of changes:*
Adding initial forward slash to the logs path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
