### PR TITLE
Fix Script example for aws:executeScript

### DIFF
--- a/doc_source/automation-action-executeScript.md
+++ b/doc_source/automation-action-executeScript.md
@@ -74,11 +74,9 @@ inputs:
  InputPayload: 
   "parameter1": "parameter_value1"
   "parameter2": "parameter_value2"
- Script: 
-  - 
-   "def script_handler(events, context):"
-  - 
-   "(script commands)"
+ Script: >
+   def script_handler(events, context):
+     (script commands)
  Attachment: "zip-file-name-1.zip"
 ```
 


### PR DESCRIPTION
*Description of changes:*

According to the documentation (below the modified example) and the CloudFormation error message, the Script has to be of type string, not list.

> Failed to create resource. Input [...] is of type ArrayList, but expected type is String.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
