### PR TITLE
Update systems-manager-setting-up-messageAPIs.md

### DIFF
--- a/doc_source/systems-manager-setting-up-messageAPIs.md
+++ b/doc_source/systems-manager-setting-up-messageAPIs.md
@@ -19,10 +19,10 @@ If you monitor API calls, you might see calls to the following APIs:
 These special calls are used by Systems Manager for various operations\.
 
 **ec2messages API calls**  
-Calls to `ec2messages:*` APIs are calls to the Amazon Message Delivery Service endpoint\. Systems Manager uses this endpoint to make calls from SSM Agent to the Systems Manager service in the cloud\. This endpoint is required to send and receive commands\. For more information, see [Actions, Resources, and Condition Keys for Amazon Message Delivery Service](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonmessagedeliveryservice.html)\.
+Calls to `ec2messages:*` APIs are calls to the Amazon Message Delivery Service endpoint\. Systems Manager uses this endpoint to make calls from SSM Agent to the Systems Manager service in the cloud\. This endpoint is required to send and receive commands\. For more information, see [Actions, Resources, and Condition Keys for Amazon Message Delivery Service](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonmessagedeliveryservice.html)\.
 
 **ssmmessages API calls**  
-Systems Manager uses the `ssmmessages` endpoint to make calls from SSM Agent to the Session Manager service in the cloud\. This endpoint is required to create and delete session channels with the Session Manager service in the cloud\.
+Systems Manager uses the `ssmmessages` endpoint to make calls from SSM Agent to the Session Manager service in the cloud\. This endpoint is required to create and delete session channels with the Session Manager service in the cloud\. For more information, see [Actions, Resources, and Condition Keys for Amazon Session Manager Message Gateway Service](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonsessionmanagermessagegatewayservice.html)\.
 
 **Instance\-related API calls**  
 `UpdateInstanceInformation`: SSM Agent calls the Systems Manager service in the cloud every five minutes to provide heartbeat information\. This call is necessary to maintain a heartbeat with the agent so that the service knows the agent is functioning as expected\. 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added reference link for Session Manager Message Gateway Service (`ssmmessages`) IAM keys
- Updated Message Deliver Service endpoint (`ec2messages`) IAM key reference link to point directly to the service-authorization guide, in case the IAM guide redirect is deprecated in the future

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
