### PR TITLE
Moved the Important notification

### DIFF
--- a/doc_source/integration-ps-secretsmanager.md
+++ b/doc_source/integration-ps-secretsmanager.md
@@ -4,9 +4,6 @@ Secrets Manager helps you organize and manage important configuration data such 
 
 For more information about Secrets Manager, see [What Is AWS Secrets Manager?](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html) in the *AWS Secrets Manager User Guide*\.
 
-**Important**  
-Parameter Store functions as a pass\-through service for references to Secrets Manager secrets\. Parameter Store doesn't retain data or metadata about secrets\. The reference is stateless\.
-
 ## Restrictions<a name="integration-ps-secretsmanager-restrictions"></a>
 
 Note the following restrictions when using Parameter Store to reference Secrets Manager secrets:
@@ -25,6 +22,9 @@ The following procedure describes how to reference a Secrets Manager secret by u
 
 **Note**  
 Before you begin, verify that you have permission to reference Secrets Manager secrets in Parameter Store parameters\. If you have administrator privileges in Secrets Manager and Systems Manager, then you can reference or retrieve secrets by using Parameter Store APIs\. If you reference a Secrets Manager secret in a Parameter Store parameter, and you don't have permission to access that secret, then the reference fails\. For more information, see [Authentication and access control for AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access.html) in the *AWS Secrets Manager User Guide*\.
+
+**Important**  
+Parameter Store functions as a pass\-through service for references to Secrets Manager secrets\. Parameter Store doesn't retain data or metadata about secrets\. The reference is stateless\.
 
 **To reference a Secrets Manager secret by using Parameter Store**
 


### PR DESCRIPTION
I totally missed that note when reading through the document. So I used the Feedback form to notify the documentation team about that notification missing. I'm proposing to show it right before a user finds the section on how to proceed with retrieving Secrets using Parameter Store API calls rather than above the list of restrictions like it is now.
 
Because I missed that **Important** note I made the incorrect assumption that in order for System Manager to process the Secret an ACTUAL Parameter referencing that Secret had to be created first, which is what that note is trying to prevent.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
