### PR TITLE
add integer to list of param types

### DIFF
--- a/doc_source/sysman-doc-syntax.md
+++ b/doc_source/sysman-doc-syntax.md
@@ -25,7 +25,7 @@ A structure that defines the parameters the document accepts\. For parameters th
 For more information about Parameter Store, see [AWS Systems Manager Parameter Store](systems-manager-parameter-store.md)\.  
 Type: Structure  
 The `parameters` structure accepts the following fields and values:  
-+ `type`: \(Required\) Allowed values include the following: `String`, `StringList`, `Boolean`, `MapList`, and `StringMap`\. To view examples of each type, see [SSM document parameter `type` examples](#top-level-properties-type) in the next section\.
++ `type`: \(Required\) Allowed values include the following: `String`, `StringList`, `Integer`, `Boolean`, `MapList`, and `StringMap`\. To view examples of each type, see [SSM document parameter `type` examples](#top-level-properties-type) in the next section\.
 **Note**  
 To use a number as a parameter value, use `String` as the parameter type\.
 + `description`: \(Optional\) A description of the parameter\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Integer is specified as a param type in the `top-level-properties-type` section, but not in the "The `parameters` structure accepts the following fields and values" section.

https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-doc-syntax.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
