### PR TITLE
Update sysman-uninstall-agent.md

### DIFF
--- a/doc_source/sysman-uninstall-agent.md
+++ b/doc_source/sysman-uninstall-agent.md
@@ -5,7 +5,7 @@ Use the following commands to uninstall AWS Systems Manager Agent \(SSM Agent\)\
 **Amazon Linux, Amazon Linux 2, CentOS, Oracle Linux, and Red Hat Enterprise Linux**
 
 ```
-sudo yum erase amazon-ssm-agent –y
+sudo yum erase amazon-ssm-agent --assumeyes
 ```
 
 **Debian Server**


### PR DESCRIPTION
-y seems not to work at this position, at least in amazon linux. However, --assumeyes is also better for readability

[ec2-user@ip-10-200-148-59 ~]$ sudo yum erase amazon-ssm-agent –y
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
No Match for argument: –y
Resolving Dependencies
--> Running transaction check
---> Package amazon-ssm-agent.x86_64 0:3.0.529.0-1.amzn2 will be erased
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package               Arch        Version                 Repository      Size
================================================================================
Removing:
 amazon-ssm-agent      x86_64      3.0.529.0-1.amzn2       installed      104 M

Transaction Summary
================================================================================
Remove  1 Package

Installed size: 104 M
Is this ok [y/N]: n

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
