### PR TITLE
Fixed URL links for Debian/Ubuntu

### DIFF
--- a/doc_source/sysman-install-managed-linux.md
+++ b/doc_source/sysman-install-managed-linux.md
@@ -34,15 +34,15 @@ https://s3.us-west-1.amazonaws.com/amazon-ssm-us-west-1/latest/linux_amd64/amazo
 + **Intel 64\-bit \(x86\_64\)**
 
   `https://s3.region.amazonaws.com/amazon-ssm-region/latest/debian_amd64/amazon-ssm-agent.deb`
-+ **Intel 32\-bit \(x86\)**
++ **ARM 64\-bit \(arm64\)**
 
-  `https://s3.region.amazonaws.com/amazon-ssm-region/latest/debian_386/amazon-ssm-agent.deb`
+  `https://s3.region.amazonaws.com/amazon-ssm-region/latest/debian_arm64/amazon-ssm-agent.deb`
 
 ------
 #### [ Debian Server ]
 + **Intel 64\-bit \(x86\_64\)**
 
-  `ttps://s3.region.amazonaws.com/amazon-ssm-region/latest/debian_amd64/amazon-ssm-agent.deb`
+  `https://s3.region.amazonaws.com/amazon-ssm-region/latest/debian_amd64/amazon-ssm-agent.deb`
 + **ARM 64\-bit \(arm64\)**
 
   `https://s3.region.amazonaws.com/amazon-ssm-region/latest/debian_arm64/amazon-ssm-agent.deb`


### PR DESCRIPTION
*Description of changes:*

- Add missing `h` in URL for Debian package
- Replaced `i386` for `arm64` link for Ubuntu package. I tested the i386 link and it was not working. I'm assuming it's not available anymore based on the fact that it's not present for the Debian section *and* that Ubuntu stopped supporting i386 2 years ago.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
