### PR TITLE
Remove invalid and unneeded SSMBucketPermissionsCheck bucket policy statements

### DIFF
--- a/doc_source/sysman-inventory-datasync.md
+++ b/doc_source/sysman-inventory-datasync.md
@@ -65,7 +65,9 @@ For information about viewing your AWS account ID, see [Your Amazon Web Services
             "Effect":"Allow",
             "Principal":{
                "Service":"ssm.amazonaws.com"
-            }
+            },
+            "Action":"s3:PutObject",
+            "Resource":"arn:aws:s3:::DOC-EXAMPLE-BUCKET/bucket-prefix/*"
          },
          {
             "Sid":" SSMBucketDelivery",
@@ -170,7 +172,9 @@ Use the following procedure to create a central Amazon S3 bucket to store aggreg
                "Effect": "Allow",
                "Principal": {
                    "Service": "ssm.amazonaws.com"
-               }
+               },
+               "Action":"s3:PutObject",
+               "Resource":"arn:aws:s3:::DOC-EXAMPLE-BUCKET/bucket-prefix/*"
            },
            {
                "Sid": " SSMBucketDelivery",

--- a/doc_source/sysman-inventory-datasync.md
+++ b/doc_source/sysman-inventory-datasync.md
@@ -61,15 +61,6 @@ For information about viewing your AWS account ID, see [Your Amazon Web Services
       "Version":"2012-10-17",
       "Statement":[
          {
-            "Sid":"SSMBucketPermissionsCheck",
-            "Effect":"Allow",
-            "Principal":{
-               "Service":"ssm.amazonaws.com"
-            },
-            "Action":"s3:PutObject",
-            "Resource":"arn:aws:s3:::DOC-EXAMPLE-BUCKET/bucket-prefix/*"
-         },
-         {
             "Sid":" SSMBucketDelivery",
             "Effect":"Allow",
             "Principal":{
@@ -167,15 +158,6 @@ Use the following procedure to create a central Amazon S3 bucket to store aggreg
    {
        "Version": "2012-10-17",
        "Statement": [
-           {
-               "Sid": "SSMBucketPermissionsCheck",
-               "Effect": "Allow",
-               "Principal": {
-                   "Service": "ssm.amazonaws.com"
-               },
-               "Action":"s3:PutObject",
-               "Resource":"arn:aws:s3:::DOC-EXAMPLE-BUCKET/bucket-prefix/*"
-           },
            {
                "Sid": " SSMBucketDelivery",
                "Effect": "Allow",


### PR DESCRIPTION
S3 bucket policy statements are invalid without `Action` and `Resource` elements