### PR TITLE
Remove invalid SSMBucketPermissionsCheck from bucket policy

### DIFF
--- a/doc_source/sysman-inventory-resource-data-sync.md
+++ b/doc_source/sysman-inventory-resource-data-sync.md
@@ -45,13 +45,6 @@ Before you start this walkthrough, you must collect inventory metadata from your
        "Version": "2012-10-17",
        "Statement": [
            {
-               "Sid": "SSMBucketPermissionsCheck",
-               "Effect": "Allow",
-               "Principal": {
-                   "Service": "ssm.amazonaws.com"
-               }
-           },
-           {
                "Sid": " SSMBucketDelivery",
                "Effect": "Allow",
                "Principal": {


### PR DESCRIPTION
*Description of changes:*
`SSMBucketPermissionsCheck` statement from the bucket policy is Missing `Action` and `Resource` elements. As per #166 this statement was removed altogether in sysman-inventory-datasync.md as the second statement covered the same permissions.

As such removing SSMBucketPermissionsCheck statement from sysman-inventory-resource-data-sync.md to align with changes made in #166

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
