### PR TITLE
Update Proxy settings for installation script

### DIFF
--- a/doc_source/sysman-install-ssm-proxy.md
+++ b/doc_source/sysman-install-ssm-proxy.md
@@ -16,7 +16,7 @@ As of January 14, 2020, Windows Server 2008 is [no longer supported](https://www
    ```
    $serviceKey = "HKLM:\SYSTEM\CurrentControlSet\Services\AmazonSSMAgent"
    $keyInfo = (Get-Item -Path $serviceKey).GetValue("Environment")
-   $proxyVariables = @("http_proxy=hostname:port", "no_proxy=169.254.169.254")
+   $proxyVariables = @("http_proxy=hostname:port", "https_proxy=hostname:port", "no_proxy=169.254.169.254")
    
    If($keyInfo -eq $null)
    {
@@ -34,7 +34,7 @@ After running the preceding command, you can review the SSM Agent logs to confir
 2020-02-24 15:31:54 INFO Getting WinHTTP proxy default configuration: The operation completed successfully.
 2020-02-24 15:31:54 INFO Proxy environment variables:
 2020-02-24 15:31:54 INFO http_proxy: hostname:port
-2020-02-24 15:31:54 INFO https_proxy: 
+2020-02-24 15:31:54 INFO https_proxy: hostname:port
 2020-02-24 15:31:54 INFO no_proxy: 169.254.169.254
 2020-02-24 15:31:54 INFO Starting Agent: amazon-ssm-agent - v2.3.871.0
 2020-02-24 15:31:54 INFO OS: windows, Arch: amd64


### PR DESCRIPTION
*Description of changes:*
SSM Agent 3.0.1390.0 and later is not using http_proxy setting for HTTPS traffics and setting https_proxy is mandatory.

Updated SSM Agent PowerShell installation script to include https_proxy.

The reason is a change in Go version 1.16 [net/http]( https://golang.org/doc/go1.16#net/http).

`The ProxyFromEnvironment function no longer returns the setting of the HTTP_PROXY environment variable for https:// URLs when HTTPS_PROXY is unset`

Here is more references about the change:

[+] https://go-review.googlesource.com/c/net/+/249440/4/http/httpproxy/proxy.go
[+] https://github.com/golang/go/issues/40909

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
