### PR TITLE
Correction to the policy example.

### DIFF
--- a/doc_source/sysman-paramstore-access.md
+++ b/doc_source/sysman-paramstore-access.md
@@ -109,11 +109,17 @@ The following example shows how to deny some commands while allowing the user to
         {
             "Effect": "Allow",
             "Action": [
+                "ssm:DescribeParameters"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
                 "ssm:GetParametersByPath",
                 "ssm:GetParameters",
                 "ssm:GetParameter",
                 "ssm:GetParameterHistory",
-                "ssm:DescribeParameters"
             ],
             "Resource": "arn:aws:ssm:region:account-id:parameter/prod-*"
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`ssm:DescribeParameters` always requires `"Resource": "*"`. We cannot give a resource arn wildcard as was given in the example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
