### PR TITLE
Fix minor typo and add reference for `automation-action-waitForAwsResourceProperty.md`

### DIFF
--- a/doc_source/automation-action-waitForAwsResourceProperty.md
+++ b/doc_source/automation-action-waitForAwsResourceProperty.md
@@ -3,7 +3,7 @@
 The `aws:waitForAwsResourceProperty` action allows your automation to wait for a specific resource state or event state before continuing the automation\. For more information and examples of how to use this action, see [Invoking other AWS services from a Systems Manager Automation runbook](automation-aws-apis-calling.md)\.
 
 **Note**  
-The default timeout value for this action is 3600 seconds \(one hour\)\. You can limit or extend the timeout by specifyingsd the `timeoutSeconds` parameter for an `aws:waitForAwsResourceProperty` step\.
+The default timeout value for this action is 3600 seconds \(one hour\)\. You can limit or extend the timeout by specifying the `timeoutSeconds` parameter for an `aws:waitForAwsResourceProperty` step\.
 
 **Input**  
 Inputs are defined by the API operation that you choose\.

--- a/doc_source/automation-action-waitForAwsResourceProperty.md
+++ b/doc_source/automation-action-waitForAwsResourceProperty.md
@@ -3,7 +3,7 @@
 The `aws:waitForAwsResourceProperty` action allows your automation to wait for a specific resource state or event state before continuing the automation\. For more information and examples of how to use this action, see [Invoking other AWS services from a Systems Manager Automation runbook](automation-aws-apis-calling.md)\.
 
 **Note**  
-The default timeout value for this action is 3600 seconds \(one hour\)\. You can limit or extend the timeout by specifying the `timeoutSeconds` parameter for an `aws:waitForAwsResourceProperty` step\.
+The default timeout value for this action is 3600 seconds \(one hour\)\. You can limit or extend the timeout by specifying the `timeoutSeconds` parameter for an `aws:waitForAwsResourceProperty` step\. For more information, see [Handling timeouts in runbooks](automation-handling-timeouts.md)\.
 
 **Input**  
 Inputs are defined by the API operation that you choose\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix minor typo and add link to [Handling timeouts in runbooks](https://github.com/awsdocs/aws-systems-manager-user-guide/blob/main/doc_source/automation-handling-timeouts.md).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
