### PR TITLE
please remove ` on Start-Process command and keep the command in one-line 

### DIFF
--- a/doc_source/sysman-install-win.md
+++ b/doc_source/sysman-install-win.md
@@ -27,21 +27,15 @@ The URLs in this step let you download SSM Agent from *any* AWS Region\. If you 
 Run the following three PowerShell commands in order\. These commands allow you to download SSM Agent without adjusting Internet Explorer \(IE\) Enhanced Security settings, and then install the agent and remove the installation file\.  
 
    ```
-   Invoke-WebRequest `
-       https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_amd64/AmazonSSMAgentSetup.exe `
-       -OutFile $env:USERPROFILE\Desktop\SSMAgent_latest.exe
+   Invoke-WebRequest `https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_amd64/AmazonSSMAgentSetup.exe` -OutFile $env:USERPROFILE\Desktop\SSMAgent_latest.exe
    ```
 
    ```
-   Invoke-WebRequest `
-       https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_386/AmazonSSMAgentSetup.exe `
-       -OutFile $env:USERPROFILE\Desktop\SSMAgent_latest.exe
+   Invoke-WebRequest `https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_386/AmazonSSMAgentSetup.exe` -OutFile $env:USERPROFILE\Desktop\SSMAgent_latest.exe
    ```
 
    ```
-   Start-Process `
-       -FilePath $env:USERPROFILE\Desktop\SSMAgent_latest.exe `
-       -ArgumentList "/S"
+   Start-Process -FilePath $env:USERPROFILE\Desktop\SSMAgent_latest.exe -ArgumentList "/S"
    ```
 
    ```


### PR DESCRIPTION
…ne while copying the command it copied as multiple lines.

please remove "`" back ticks on Start-Process -FilePath $env:USERPROFILE\Desktop\SSMAgent_latest.exe -ArgumentList "/S" because of it the command throwing the error and keep the command's in single line while coping the commands all are copied as multi line commands and those are throwing error while running them in power-shell.

*Issue #, if available:*

*Description of changes:*
removed ` on Start-Process command and made all commands in single line to avoid error while running in powershell.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
