### PR TITLE
Wrong document name for remote port forwarding

### DIFF
--- a/doc_source/session-manager-working-with-sessions-start.md
+++ b/doc_source/session-manager-working-with-sessions-start.md
@@ -176,7 +176,7 @@ aws ssm start-session \
 ```
 aws ssm start-session ^
     --target instance-id ^
-    --document-name SSM-StartPortForwardingSessionToRemoteHost ^
+    --document-name AWS-StartPortForwardingSessionToRemoteHost ^
     --parameters host="mydb.example.us-east-2.rds.amazonaws.com",portNumber="3306",localPortNumber="3306"
 ```
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
The Windows example for creating a remote port forwarding session contained an error in the called SSM document ("SSM-" instead of "AWS-").

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
