### PR TITLE
Update SSM Document ARN for AWS-managed document

### DIFF
--- a/doc_source/automation-cwe-target.md
+++ b/doc_source/automation-cwe-target.md
@@ -256,7 +256,7 @@ The following procedure describes how to use the AWS CLI \(on Linux or Windows\)
    ```
    aws events put-targets \
        --rule DailyAutomationRule \
-       --targets '{"Arn": "arn:aws:ssm:us-east-1:123456789012:automation-definition/AWS-StartEC2Instance","Input":"{\"InstanceId\":[\"i-02573cafcfEXAMPLE\"],\"AutomationAssumeRole\":[\"arn:aws:iam::123456789012:role/AutomationServiceRole\"]}","Id": "Target1","RoleArn": "arn:aws:iam::123456789012:role/service-role/AWS_Events_Invoke_Start_Automation_Execution_1213609520"}'
+       --targets '{"Arn": "arn:aws:ssm:us-east-1::automation-definition/AWS-StartEC2Instance","Input":"{\"InstanceId\":[\"i-02573cafcfEXAMPLE\"],\"AutomationAssumeRole\":[\"arn:aws:iam::123456789012:role/AutomationServiceRole\"]}","Id": "Target1","RoleArn": "arn:aws:iam::123456789012:role/service-role/AWS_Events_Invoke_Start_Automation_Execution_1213609520"}'
    ```
 
 ------
@@ -265,7 +265,7 @@ The following procedure describes how to use the AWS CLI \(on Linux or Windows\)
    ```
    aws events put-targets ^
        --rule DailyAutomationRule ^
-       --targets '{"Arn": "arn:aws:ssm:us-east-1:123456789012:automation-definition/AWS-StartEC2Instance","Input":"{\"InstanceId\":[\"i-02573cafcfEXAMPLE\"],\"AutomationAssumeRole\":[\"arn:aws:iam::123456789012:role/AutomationServiceRole\"]}","Id": "Target1","RoleArn": "arn:aws:iam::123456789012:role/service-role/AWS_Events_Invoke_Start_Automation_Execution_1213609520"}'
+       --targets '{"Arn": "arn:aws:ssm:us-east-1::automation-definition/AWS-StartEC2Instance","Input":"{\"InstanceId\":[\"i-02573cafcfEXAMPLE\"],\"AutomationAssumeRole\":[\"arn:aws:iam::123456789012:role/AutomationServiceRole\"]}","Id": "Target1","RoleArn": "arn:aws:iam::123456789012:role/service-role/AWS_Events_Invoke_Start_Automation_Execution_1213609520"}'
    ```
 
 ------
@@ -274,7 +274,7 @@ The following procedure describes how to use the AWS CLI \(on Linux or Windows\)
    ```
    $Target = New-Object Amazon.CloudWatchEvents.Model.Target
    $Target.Id = "Target1"
-   $Target.Arn = "arn:aws:ssm:us-east-1:123456789012:automation-definition/AWS-StartEC2Instance"
+   $Target.Arn = "arn:aws:ssm:us-east-1::automation-definition/AWS-StartEC2Instance"
    $Target.RoleArn = "arn:aws:iam::123456789012:role/service-role/AWS_Events_Invoke_Start_Automation_Execution_1213609520"
    $Target.Input = '{"InstanceId":["i-02573cafcfEXAMPLE"],"AutomationAssumeRole":["arn:aws:iam::123456789012:role/AutomationServiceRole"]}'
    


### PR DESCRIPTION
I believe that for AWS Managed Documents, the account number should be omitted from the ARN.

*Description of changes:*
Removed account number from the ARN of the `AWS-StartEC2Instance` document.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
