### PR TITLE
fix  InvalidDocumentContent on  RunbookTutorialChildAutomation

### DIFF
--- a/doc_source/automation-authoring-runbooks-parent-child-example.md
+++ b/doc_source/automation-authoring-runbooks-parent-child-example.md
@@ -172,16 +172,15 @@ To start creating her runbook content, Emily reviews the available automation ac
        onFailure: Abort
        inputs:
          Choices:
-           - NextStep: startInstance
-             Variable: '{{getInstanceState.instanceState}}'
-             StringEquals: stopped
-           - Or:
-               - Variable: '{{getInstanceState.instanceState}}'
-                 StringEquals: stopping
-             NextStep: verifyInstanceStopped
-           - NextStep: patchInstance
-             Variable: '{{getInstanceState.instanceState}}'
-             StringEquals: running
+         - NextStep: startInstance
+           Variable: '{{getInstanceState.instanceState}}'
+           StringEquals: stopped
+         - NextStep: verifyInstanceStopped
+           Variable: '{{getInstanceState.instanceState}}'
+           StringEquals: stopping
+         - NextStep: patchInstance
+           Variable: '{{getInstanceState.instanceState}}'
+           StringEquals: running
        isEnd: true
      - name: startInstance
        action: 'aws:executeAwsApi'
@@ -455,16 +454,15 @@ To start creating her runbook content, Emily reviews the available automation ac
        onFailure: Abort
        inputs:
          Choices:
-           - NextStep: startInstance
-             Variable: '{{getInstanceState.instanceState}}'
-             StringEquals: stopped
-           - Or:
-               - Variable: '{{getInstanceState.instanceState}}'
-                 StringEquals: stopping
-             NextStep: verifyInstanceStopped
-           - NextStep: patchInstance
-             Variable: '{{getInstanceState.instanceState}}'
-             StringEquals: running
+         - NextStep: startInstance
+           Variable: '{{getInstanceState.instanceState}}'
+           StringEquals: stopped
+         - NextStep: verifyInstanceStopped
+           Variable: '{{getInstanceState.instanceState}}'
+           StringEquals: stopping
+         - NextStep: patchInstance
+           Variable: '{{getInstanceState.instanceState}}'
+           StringEquals: running
        isEnd: true
      - name: startInstance
        action: 'aws:executeAwsApi'


### PR DESCRIPTION
  InvalidDocumentContent: Expect at lease two expressions for operator: Or in step: branchOnInstanceState. Provided: 1 at ssm document creation.
The -Or operator is not well formatted.

*Issue #, if available:*

*Description of changes:*
The -Or operator is not well formatted need to be fixed otherwise ssm console will show a error and wont allow document creation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
