### PR TITLE
Update sysman-patch-group-tagging.md

### DIFF
--- a/doc_source/sysman-patch-group-tagging.md
+++ b/doc_source/sysman-patch-group-tagging.md
@@ -35,7 +35,7 @@ If a managed node you expect to see isn't listed, see [Troubleshooting managed n
 
 1. In the left column, enter **Patch Group**\.
 
-1. In the right column, enter a value that helps you understand which instances will be patched\.
+1. In the right column, enter the name of the Patch Group\.
 
 1. Choose **Save**\.
 
@@ -53,7 +53,7 @@ If a managed node you expect to see isn't listed, see [Troubleshooting managed n
 
 1. For **Key**, enter **Patch Group**\.
 
-1. For **Value**, enter a value that helps you understand which instances will be patched\.
+1. For **Value**, enter the name of the Patch Group\.
 
 1. Choose **Save**\.
 
@@ -83,7 +83,7 @@ If a managed node you expect to see isn't listed, see [Troubleshooting managed n
 
 1. In the left column, enter **Patch Group**\.
 
-1. In the right column, enter a value that helps you understand which managed nodes will be patched\.
+1. In the right column, enter the name of the Patch Group\.
 
 1. Choose **Save**\.
 


### PR DESCRIPTION
The sentence "enter a value that helps you understand which instances will be patched" reads as if it would technically make no difference which value you enter. Rather, however, the exact identifier of the respective patch group must be specified so that appropriately tagged EC2 instances can be assigned to a patch group. More here: https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-patch-patchgroups.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
