### PR TITLE
Provide example for downloadContent when using Git sourcetype

### DIFF
--- a/doc_source/ssm-plugins.md
+++ b/doc_source/ssm-plugins.md
@@ -932,6 +932,9 @@ Additionally, you can specify the following optional parameters:
     The default is `master`\.
 
     `"branch"` is required only if your SSM document is stored in a branch other than `master`\.
+    ```
+    "getOptions": "branch:refs/head/main",
+    ```
   + commitID:*commitID*
 
     The default is `head`\.


### PR DESCRIPTION
It wasn't obvious that the branch name needed to be a github ref path so I added an example to show what is expected.

*Issue #, if available:*

*Description of changes:*
Added an example which shows how the branch name should be specified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
