### PR TITLE
Remove extra step on the Sessions Manager Viewing History page

### DIFF
--- a/doc_source/session-manager-working-with-view-history.md
+++ b/doc_source/session-manager-working-with-view-history.md
@@ -26,8 +26,6 @@ You can use the AWS Systems Manager console to view details about the sessions i
 
 1. In the navigation pane, choose **Session Manager**\.
 
-1. Choose **Configure Preferences**\.
-
 1. Choose the **Session history** tab\.
 
 ## Viewing session history \(AWS CLI\)<a name="view-history-cli"></a>


### PR DESCRIPTION
*Description of changes:*

This PR removes an extra step on the "Session Manager: View session history" page. The step seems to be redundant as the  **Session history** tab is available straight from the **Session Manager** page (No need to go to **Preferences** first).

<img width="1792" alt="Screenshot 2023-01-20 at 10 07 22" src="https://user-images.githubusercontent.com/45905756/213647160-6804bee2-27e5-4da0-a42a-4bf8ea3b3acf.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
