### PR TITLE
Fix SSM Automation automation-action-executeScript python example code

### DIFF
--- a/doc_source/automation-action-executeScript.md
+++ b/doc_source/automation-action-executeScript.md
@@ -132,19 +132,20 @@ mainSteps:
         InputPayload:
           instanceId: '{{InstanceId}}'
         Script: |-
-          def getInstanceStates(events,context):
-          import boto3
+          def tagInstance(events,context):
+            import boto3
 
-          #Initialize client
-          ec2 = boto3.client('ec2')
-          instanceId = events['instanceId']
-          tag = {
-              "Env": "Example"
-          }
-          ec2.create_tags(
-              Resources=[instanceId],
-              Tags=[tag]
-          )
+            #Initialize client
+            ec2 = boto3.client('ec2')
+            instanceId = events['instanceId']
+            tag = {
+                "Key": "Env",
+                "Value": "Example"
+            }
+            ec2.create_tags(
+                Resources=[instanceId],
+                Tags=[tag]
+            )
 ```
 
 ```

--- a/doc_source/automation-authoring-runbooks-parent-child-example.md
+++ b/doc_source/automation-authoring-runbooks-parent-child-example.md
@@ -113,7 +113,6 @@ To start creating her runbook content, Emily reviews the available automation ac
        action: 'aws:executeAwsApi'
        onFailure: Abort
        inputs:
-         inputs:
          Service: ec2
          Api: DescribeInstances
          InstanceIds:


### PR DESCRIPTION
*Issue #, if available:*
*Description of changes:*

The python example mentioned for the [executeScript](https://docs.aws.amazon.com/systems-manager/latest/userguide/automation-action-executeScript.html) is not executable due to minor errors.
1. Indentation for the function is incorrect
2. The function name doesn't match the handler
3. The boto3 ec2.createTags expects Key and Value as input without which it returns an error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
