### PR TITLE
Correction to minimal policy

### DIFF
--- a/doc_source/getting-started-create-iam-instance-profile.md
+++ b/doc_source/getting-started-create-iam-instance-profile.md
@@ -40,13 +40,6 @@ Use the following procedure to create a custom IAM role with a policy that provi
            {
                "Effect": "Allow",
                "Action": [
-                   "s3:GetEncryptionConfiguration"
-               ],
-               "Resource": "*"
-           },
-           {
-               "Effect": "Allow",
-               "Action": [
                    "kms:Decrypt"
                ],
                "Resource": "key-name"


### PR DESCRIPTION

*Issue #, if available:*
N/A

*Description of changes:*
The `s3:GetEncryptionConfiguration` is not needed in the minimal policy without SSM session logging (this was confirmed by AWS Support)

The policy is supposed to be minimal and for the scenario where you are not doing logging. Further down the page there is a policy for when you do want logging enabled. Also, I presume the `s3:GetEncryptionConfiguration` action alone would not be enough to allow logging anyway - you'd also need `S3:PutObject` permissions



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
