### PR TITLE
docs: example should contain conditional statement

### DIFF
--- a/doc_source/getting-started-sessiondocumentaccesscheck.md
+++ b/doc_source/getting-started-sessiondocumentaccesscheck.md
@@ -58,7 +58,12 @@ With this condition element set to `true`, explicit access to a Session document
     "Resource": [
         "arn:aws:ec2:us-west-2:123456789012:instance/i-02573cafcfEXAMPLE",
         "arn:aws:ssm:us-west-2:123456789012:document/SSM-SessionManagerRunShell"
-    ] 
+    ],
+    "Condition": {
+        "BoolIfExists": {
+            "ssm:SessionDocumentAccessCheck": "true"
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the example statement, a condition was added which I assume was missing since the paragraph above the change was discussing the use of `ssm:SessionDocumentAccessCheck` to limit access to what session documents can be used by an IAM identity. 

If the intent was to give an example of a policy statement which uses `ssm:SessionDocumentAccessCheck`, then the update in this PR gives the correct policy statement that can be used as a proper example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
